### PR TITLE
Application Developer User Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 ---
-title: Service Binding for Kubernetes
 permalink: /
 ---
 
@@ -7,160 +6,17 @@ Today in Kubernetes, the exposure of secrets for connecting application workload
 
 This project specifies a Kubernetes-wide specification for communicating service secrets to workloads in an automated way.  It aims to create a widely applicable mechanism but _without_ excluding other strategies for systems that it does not fit easily.  The benefit of Kubernetes-wide specification is that all of the actors in an ecosystem can work towards a clearly defined abstraction at the edge of their expertise and depend on other parties to complete the chain.
 
-* Application Developers expect their secrets to be exposed consistently and predictably.
-* Service Providers expect their secrets to be collected and exposed to users consistently and predictably.
-* Platforms expect to retrieve secrets from Service Providers and expose them to Application Developers consistently and predictably.
+## User Guides
+To get started, please check out the guide for the appropriate role
 
-# Consuming the Bindings from Workloads
-The [Workload Projection section](https://github.com/k8s-service-bindings/spec#workload-projection) of the specification describes how bindings are projected into the workload.  The primary mechanism of projection is through files mounted at a specific directory.  The bindings directory path is discovered through the mandatory `$SERVICE_BINDING_ROOT` environment variable set on all containers where bindings are created.
+* [Application Developer](/application-developer/)
+  Expects secrets to be exposed consistently and predictably
+* [Service Provider](/service-provider/)
+  Expects secrets to be collected consistently and predictably
+* [Application Operator](/application-operator/)
+  Expects secrets to be transferred from services to workloads consistently and predictably
 
-Within this service binding root directory, multiple Service Bindings may be projected.  For example, a workload that requires both a database and event stream will declare one `ServiceBinding` for the database, a second `ServiceBinding` for the event stream, and both bindings will be projected as subdirectories of the root.
-
-Let's take a look at the example given in the spec:
-
-```
-$SERVICE_BINDING_ROOT
-├── account-database
-│   ├── type
-│   ├── provider
-│   ├── uri
-│   ├── username
-│   └── password
-└── transaction-event-stream
-    ├── type
-    ├── connection-count
-    ├── uri
-    ├── certificates
-    └── private-key
-```
-In the above example, there are two bindings under the `$SERVICE_BINDING_ROOT` directory with the names `account-database` and `transaction-event-stream`.  In order for a workload to configure itself, it must select the proper binding for each client type.  Each binding directory has a special file named `type` and you can use the content of that file to identify the type of the binding projected into that directory (e.g. `mysql`, `kafka`).  Some bindings optionally also contain another special file named `provider` which is an additional identifier used to further narrow down ambiguous types.  Choosing a binding "by-name" is not considered good practice as it makes your workload less portable (although it may be unavoidable).  Wherever possible use the `type` field and, if necessary, `provider` to select a binding.
-
-Usually, operators use `ServiceBinding` resource name (`.metadata.name`) as the bindings directory name, but the spec also provides a way to override that name through the `.spec.name` field. So, there is a chance for bindings name collision.  However, due to the nature of the volume mount in Kubernetes, the bindings directory will contain values from only one of the Secret resources.  This is a caveat of using the bindings directory name to look up the bindings.
-
-### Purpose of the type and the provider fields in the workload projection
-
-The specification mandates the `type` field and recommends `provider` field in the projected binding.  In many cases the `type` field should be good enough to select the appropriate binding.  In cases where it is not (e.g. when there are different providers for the same Provisioned Service), the `provider` field may be used.  For example, when the type is `mysql`, the `provider` value might be `mariadb`, `oracle`, `bitnami`, `aws-rds`, etc.  When the workload is selecting a binding, if necessary, it could consider `type` and `provider` as a composite key to avoid ambiguity.  This could be helpful if a workload needs to choose a particular provider based on the deployment environment.  In the deployment environment (`stage`, `prod`, etc.), at any given time, you need to ensure only one binding projection exists for a given `type` or `type` and `provider` -- unless your workload needs to connect to all the services.
-
-### Environment Variables
-
-The specification also has support for projecting binding values as environment variables.  You can use the built-in language feature of your programming language of choice to read environment variables.  The container must restart to read updated environment variable values.
-
-# Programmatic Language Bindings
-While the projection of a binding into a `Pod` can be consumed directly with features typically found in any programming language, it is often preferable to use a language binding that adds semantic meaning to the interaction.  For example:
-
-### Java
-_(Example taken from <https://github.com/nebhale/client-jvm>)_
-
-```java
-import com.nebhale.bindings.Binding;
-import com.nebhale.bindings.Bindings;
-
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-
-public class Application {
-
-    public static void main(String[] args) {
-        Binding[] bindings = Bindings.fromServiceBindingRoot();
-        bindings = Bindings.filter(bindings, "postgresql");
-        if (bindings.length != 1) {
-            System.err.printf("Incorrect number of PostgreSQL drivers: %d\n", bindings.length);
-            System.exit(1);
-        }
-
-        String url = bindings[0].get("url");
-        if (url == null) {
-            System.err.println("No URL in binding");
-            System.exit(1);
-        }
-
-        Connection conn;
-        try {
-            conn = DriverManager.getConnection(url);
-        } catch (SQLException e) {
-            System.err.printf("Unable to connect to database: %s", e);
-            System.exit(1);
-        }
-
-        // ...
-    }
-
-}
-```
-
-### Go
-_(Example taken from <https://github.com/baijum/servicebinding>)_
-
-```go
-import (
-	"context"
-	"fmt"
-	"github.com/jackc/pgx/v4"
-	"github.com/baijum/servicebinding/binding"
-	"os"
-)
-
-func main() {
-	sb, err := bindings.FromServiceBindingRoot()
-	if err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, "Could not read service bindings")
-		os.Exit(1)
-	}
-
-	b, err := sb.Bindings("postgresql")
-	if err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, "Unable to find postgresql binding")
-		os.Exit(1)
-	}
-	if len(b) != 1 {
-		_, _ = fmt.Fprintf(os.Stderr, "Incorrect number of PostgreSQL bindings: %d\n", len(b))
-		os.Exit(1)
-	}
-
-	u, ok := b[0]["url"]
-	if !ok {
-		_, _ = fmt.Fprintln(os.Stderr, "No URL in binding")
-		os.Exit(1)
-	}
-
-	conn, err := pgx.Connect(context.Background(), u)
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Unable to connect to database: %v\n", err)
-		os.Exit(1)
-	}
-	defer conn.Close(context.Background())
-
-	// ...
-}
-```
-
-## Known Language Bindings
-_(If you've created an implementation, please [submit a PR][p] for inclusion)_
-
-[p]: https://github.com/servicebinding/website/pulls
-
-* .NET
-	* [`donschenck/dotnetservicebinding`](https://github.com/donschenck/dotnetservicebinding)
-* Go
-	* [`baijum/servicebinding`](https://github.com/baijum/servicebinding)
-	* [`nebhale/client-go`](https://github.com/nebhale/client-go)
-* JVM
-	* [`nebhale/client-jvm`](https://github.com/nebhale/client-jvm)
-	* [Quarkus](https://quarkus.io/guides/deploying-to-kubernetes#service-binding)
-	* [Spring Cloud Bindings](https://github.com/spring-cloud/spring-cloud-bindings)
-* NodeJS
-	* [`nebhale/client-nodejs`](https://github.com/nebhale/client-nodejs)
-	* [`nodeshift/kube-service-bindings`](https://github.com/nodeshift/kube-service-bindings)
-* Python
-	* [`baijum/pyservicebinding`](https://github.com/baijum/pyservicebinding)
-	* [`nebhale/client-python`](https://github.com/nebhale/client-python)
-* Ruby
-	* [`nebhale/client-ruby`](https://github.com/nebhale/client-ruby)
-* Rust
-	* [`nebhale/client-rust`](https://github.com/nebhale/client-rust)
-
-# Specification
+## Specification
 * Core
   * [1.0.0-rc3](/spec/core/1.0.0-rc3/) (pre-release)
   * [1.0.0-rc2](/spec/core/1.0.0-rc2/) (pre-release)

--- a/_config.yml
+++ b/_config.yml
@@ -7,3 +7,6 @@ description: Bind Services to Kubernetes Workloads
 
 github:
   is_project_page: false
+
+spec:
+  core: /spec/core/1.0.0-rc3/

--- a/_includes/important.html
+++ b/_includes/important.html
@@ -1,0 +1,3 @@
+<div markdown="span" class="alert alert-warning" role="alert"><i class="fa fa-warning"></i> <b>Important:</b> {{include.content}}</div>
+
+{% comment %} Copyright 2021 Google LLC {% endcomment %}

--- a/_includes/note.html
+++ b/_includes/note.html
@@ -1,0 +1,3 @@
+<div markdown="span" class="alert alert-info" role="alert"><i class="fa fa-info-circle"></i> <b>Note:</b> {{include.content}}</div>
+
+{% comment %} Copyright 2021 Google LLC {% endcomment %}

--- a/_includes/tip.html
+++ b/_includes/tip.html
@@ -1,0 +1,3 @@
+<div markdown="span" class="alert alert-success" role="alert"><i class="fa fa-check-square-o"></i> <b>Tip:</b> {{include.content}}</div>
+
+{% comment %} Copyright 2021 Google LLC {% endcomment %}

--- a/_includes/warning.html
+++ b/_includes/warning.html
@@ -1,0 +1,3 @@
+<div markdown="span" class="alert alert-danger" role="alert"><i class="fa fa-exclamation-circle"></i> <b>Warning:</b> {{include.content}}</div>
+
+{% comment %} Copyright 2021 Google LLC {% endcomment %}

--- a/application-developer.md
+++ b/application-developer.md
@@ -1,0 +1,152 @@
+---
+description: Service Bindings for Application Developers
+permalink: /application-developer/
+---
+
+Application developers consume service bindings by reading [volume mounted `Secret`s][vm] from a directory.  The specification's [Workload Projection section][wp] describes this in detail but there are three important parts:
+
+[vm]: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod
+[wp]: {{ site.spec.core }}#workload-projection
+
+1. A `SERVICE_BINDING_ROOT` environment variable that specifies the directory
+2. A subdirectory for each  binding with a name matching the binding name
+3. A file for each `Secret` entry with a name matching the entry key and content matching the entry value
+
+Let's take a look at the [example][eds] given in the spec:
+
+[eds]: {{ site.spec.core }}#example-directory-structure
+
+```plain
+$SERVICE_BINDING_ROOT
+├── account-database
+│   ├── type
+│   ├── provider
+│   ├── uri
+│   ├── username
+│   └── password
+└── transaction-event-stream
+    ├── type
+    ├── connection-count
+    ├── uri
+    ├── certificates
+    └── private-key
+```
+
+In the example, there are two bindings under the `$SERVICE_BINDING_ROOT` directory with the names `account-database` and `transaction-event-stream`.  In order for a workload to configure itself, it must select the proper binding for each client type.  Each binding directory has a special file named `type` that is used to identify the type of the binding projected into that directory (e.g. `mysql`, `kafka`).
+
+In most cases, the `type` entry should be enough to select the appropriate binding.  In the cases where it is not (e.g. when there are different providers for the same service type), the optional but strongly encouraged `provider` entry should be used to further differentiate bindings.  For example, when the `type` is `mysql`, `provider` values of `mariadb`, `oracle`, `bitnami`, or `aws-rds` can be used to choose a binding.
+
+{% include tip.html content="Wherever possible select a binding using the `type` entry and, if necessary, the `provider` entry.  Consider using the name of the binding only as a last resort." %}
+
+# Language-specific Libraries
+A binding can almost always be consumed directly with features found in any programming language.  However, it's often preferable to use a language-specific library that adds semantic meaning to the code.  There's no "right" way to interact with a binding, so here's a partial list of libraries you might use:
+
+* .NET
+	* [`donschenck/dotnetservicebinding`](https://github.com/donschenck/dotnetservicebinding)
+* Go
+	* [`baijum/servicebinding`](https://github.com/baijum/servicebinding)
+	* [`nebhale/client-go`](https://github.com/nebhale/client-go)
+* JVM
+	* [`nebhale/client-jvm`](https://github.com/nebhale/client-jvm)
+	* [Quarkus](https://quarkus.io/guides/deploying-to-kubernetes#service-binding)
+	* [Spring Cloud Bindings](https://github.com/spring-cloud/spring-cloud-bindings)
+* NodeJS
+	* [`nebhale/client-nodejs`](https://github.com/nebhale/client-nodejs)
+	* [`nodeshift/kube-service-bindings`](https://github.com/nodeshift/kube-service-bindings)
+* Python
+	* [`baijum/pyservicebinding`](https://github.com/baijum/pyservicebinding)
+	* [`nebhale/client-python`](https://github.com/nebhale/client-python)
+* Ruby
+	* [`nebhale/client-ruby`](https://github.com/nebhale/client-ruby)
+* Rust
+	* [`nebhale/client-rust`](https://github.com/nebhale/client-rust)
+
+{% include note.html content="If you've created an implementation, please [submit a PR](https://github.com/servicebinding/website/pulls) for inclusion." %}
+
+To illustrate the advantages of of using a library, here are a few examples:
+
+### Java
+```java
+import com.nebhale.bindings.Binding;
+import com.nebhale.bindings.Bindings;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public class Application {
+
+    public static void main(String[] args) {
+        Binding[] bindings = Bindings.fromServiceBindingRoot();
+        bindings = Bindings.filter(bindings, "postgresql");
+        if (bindings.length != 1) {
+            System.err.printf("Incorrect number of PostgreSQL drivers: %d\n", bindings.length);
+            System.exit(1);
+        }
+
+        String url = bindings[0].get("url");
+        if (url == null) {
+            System.err.println("No URL in binding");
+            System.exit(1);
+        }
+
+        Connection conn;
+        try {
+            conn = DriverManager.getConnection(url);
+        } catch (SQLException e) {
+            System.err.printf("Unable to connect to database: %s", e);
+            System.exit(1);
+        }
+
+        // ...
+    }
+
+}
+```
+_(Example taken from <https://github.com/nebhale/client-jvm>)_
+
+
+### Go
+```go
+import (
+	"context"
+	"fmt"
+	"github.com/jackc/pgx/v4"
+	"github.com/baijum/servicebinding/binding"
+	"os"
+)
+
+func main() {
+	sb, err := bindings.FromServiceBindingRoot()
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, "Could not read service bindings")
+		os.Exit(1)
+	}
+
+	b, err := sb.Bindings("postgresql")
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, "Unable to find postgresql binding")
+		os.Exit(1)
+	}
+	if len(b) != 1 {
+		_, _ = fmt.Fprintf(os.Stderr, "Incorrect number of PostgreSQL bindings: %d\n", len(b))
+		os.Exit(1)
+	}
+
+	u, ok := b[0]["url"]
+	if !ok {
+		_, _ = fmt.Fprintln(os.Stderr, "No URL in binding")
+		os.Exit(1)
+	}
+
+	conn, err := pgx.Connect(context.Background(), u)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Unable to connect to database: %v\n", err)
+		os.Exit(1)
+	}
+	defer conn.Close(context.Background())
+
+	// ...
+}
+```
+_(Example taken from <https://github.com/baijum/servicebinding>)_

--- a/application-operator.md
+++ b/application-operator.md
@@ -1,0 +1,10 @@
+---
+description: Service Bindings for Application Operators
+permalink: /application-application-operator/
+---
+
+# TODO
+
+<!-- ## Environment Variables
+
+The specification also has support for projecting binding values as environment variables.  You can use the built-in language feature of your programming language of choice to read environment variables.  The container must restart to read updated environment variable values. -->

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,98 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+.alert {
+  padding: 15px;
+  margin-bottom: 20px;
+  border: 1px solid transparent;
+  border-radius: 4px
+}
+
+.alert h4 {
+  margin-top: 0;
+  color: inherit
+}
+
+.alert .alert-link {
+  font-weight: 700
+}
+
+.alert>p,
+.alert>ul {
+  margin-bottom: 0
+}
+
+.alert>p+p {
+  margin-top: 5px
+}
+
+.alert-dismissable,
+.alert-dismissible {
+  padding-right: 35px
+}
+
+.alert-dismissable .close,
+.alert-dismissible .close {
+  position: relative;
+  top: -2px;
+  right: -21px;
+  color: inherit
+}
+
+.alert-success {
+  color: #3c763d;
+  background-color: #dff0d8;
+  border-color: #d6e9c6
+}
+
+.alert-success hr {
+  border-top-color: #c9e2b3
+}
+
+.alert-success .alert-link {
+  color: #2b542c
+}
+
+.alert-info {
+  color: #31708f;
+  background-color: #d9edf7;
+  border-color: #bce8f1
+}
+
+.alert-info hr {
+  border-top-color: #a6e1ec
+}
+
+.alert-info .alert-link {
+  color: #245269
+}
+
+.alert-warning {
+  color: #8a6d3b;
+  background-color: #fcf8e3;
+  border-color: #faebcc
+}
+
+.alert-warning hr {
+  border-top-color: #f7e1b5
+}
+
+.alert-warning .alert-link {
+  color: #66512c
+}
+
+.alert-danger {
+  color: #a94442;
+  background-color: #f2dede;
+  border-color: #ebccd1
+}
+
+.alert-danger hr {
+  border-top-color: #e4b9c0
+}
+
+.alert-danger .alert-link {
+  color: #843534
+}

--- a/service-provider.md
+++ b/service-provider.md
@@ -1,0 +1,6 @@
+---
+description: Service Bindings for Service Providers
+permalink: /service-provider/
+---
+
+# TODO


### PR DESCRIPTION
This change updates the User Guide to split the main landing page into multiple role-centric pages and links to them from the landing page. It also enhances the application-developer content.

Note that this isn't intended to be a complete user-guide implementation, simply the documentation for one of the primary roles.

[servicebinding/spec#84]
