### PR TITLE
Render Code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,7 @@
-# Contributor Covenant Code of Conduct
+---
+title: Contributor Covenant Code of Conduct
+permalink: /code-of-conduct/
+---
 
 ## Our Pledge
 

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ Participation in the Service Binding community is governed by the [Contributor C
 [working-group]: https://docs.google.com/document/d/1rR0qLpsjU38nRXxeich7F5QUy73RHJ90hnZiFIQ-JJ8/edit#heading=h.ar8ibc31ux6f
 [slack]: https://kubernetes.slack.com/archives/C012F2GPMTQ
 [github]: https://github.com/servicebinding
-[code-of-conduct]: ./CODE_OF_CONDUCT.md
+[code-of-conduct]: /code-of-conduct/


### PR DESCRIPTION
This change adds a rendered version of the Code of Conduct and updates the link from the website to point at that rendered version.