### PR TITLE
Remove Steeltoe from language-specific libraries

### DIFF
--- a/application-developer.md
+++ b/application-developer.md
@@ -50,7 +50,6 @@ adds semantic meaning to the code.  There's no "right" way to interact with a bi
 
 * .NET
 	* [`donschenck/dotnetservicebinding`](https://github.com/donschenck/dotnetservicebinding)
-	* [Steeltoe](https://docs.steeltoe.io/api/v3/connectors/)
 * Go
 	* [`baijum/servicebinding`](https://github.com/baijum/servicebinding)
 	* [`nebhale/client-go`](https://github.com/nebhale/client-go)


### PR DESCRIPTION
According to Steeltoe 3.x's docs it does not support service bindings
yet. See https://docs.steeltoe.io/api/v3/connectors/usage.html#kubernetes.

However, support is planned for 4.0. See
https://github.com/SteeltoeOSS/Steeltoe/issues/1244.

Signed-off-by: Max Brauer <mbrauer@vmware.com>
